### PR TITLE
Fix urlCheck Function

### DIFF
--- a/PayloadManager.py
+++ b/PayloadManager.py
@@ -169,14 +169,16 @@ class Payload:
 
 	# Checks if the url is valid
 	def urlCheck(self):
+		# Extract the domain with protocol from the provided url
+		self.domain = urllib.parse.urlparse(self.url).scheme + '://' + urllib.parse.urlparse(self.url).netloc
 		try:
 			print("Checking Remote Server Health")
 			if self.proxies:
-				ret = requests.get(self.url, headers=fetchUA(), proxies=fetch_proxy(), verify=False)
+				ret = requests.get(self.domain, headers=fetchUA(), proxies=fetch_proxy(), verify=False)
 			elif self.creds is not None:
 				ret = self.cred(self.url)
 			else:
-				ret = requests.get(self.url, headers=fetchUA(), verify=False)
+				ret = requests.get(self.domain, headers=fetchUA(), verify=False)
 			if ret.status_code == 200:
 				print(colored(str(ret.status_code) +" - OK",'green'))
 				return True


### PR DESCRIPTION
| name            | title       | about |
|   ---                |     ---     |    --- |
| Bug Report   |  urlCheck Function Fix | urlCheck Function checks the Remote Server Health via the endpoint provided    |

**Describe the bug**
urlCheck Function checks the Remote Server health via the provided url including the endpoint. That can result in False statements because an endpoint can return status code 404 and that doesn't mean that the server is down.

**Expected behavior**
The tool should check if the server is down via it's domain and not it's endpoint

**POC**
_urlCheck.py_
```python
import requests

url = 'http://134.209.188.36:30000'
endpoint_with_lfi = '/miner/'

print(requests.get(url).status_code)

print(requests.get(url+endpoint_with_lfi).status_code) 
```
```bash
$ python urlCheck.py 
200
404
```